### PR TITLE
dev/catalog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.jayway.version>2.6.0</dep.jayway.version>
         <dep.ratis.version>2.2.0</dep.ratis.version>
+        <dep.curator.version>4.2.0</dep.curator.version>
         <!--
           America/Bahia_Banderas has:
            - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
@@ -1887,6 +1888,38 @@
                 </exclusions>
             </dependency>
 
+            <!-- curator for zookeeper ::start:: -->
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-framework</artifactId>
+                <version>${dep.curator.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-client</artifactId>
+                <version>4.2.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.curator</groupId>
+                <artifactId>curator-recipes</artifactId>
+                <version>4.2.0</version>
+            </dependency>
+            <!-- curator for zookeeper ::end:: -->
+
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
@@ -2197,7 +2230,7 @@
                 <plugin>
                     <groupId>org.skife.maven</groupId>
                     <artifactId>really-executable-jar-maven-plugin</artifactId>
-                    <version>1.0.5</version>
+                    <version>2.1.1</version>
                 </plugin>
 
                 <plugin>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
-        <dep.curator.version>2.12.0</dep.curator.version>
+        <dep.curator.version>4.2.0</dep.curator.version>
         <dep.reload4j.version>1.2.18.3</dep.reload4j.version>
     </properties>
 

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -53,3 +53,8 @@ plugin.bundles=\
 
 presto.version=testversion
 node-scheduler.include-coordinator=true
+
+catalog.dynamic.enabled=true
+catalog.dynamic.zk.address=localhost:2181
+catalog.dynamic.zk.namespace=presto
+catalog.dynamic.zk.path=/catalog/metadata

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -164,6 +164,12 @@
         <dependency>
             <groupId>io.airlift.resolver</groupId>
             <artifactId>resolver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -479,6 +485,46 @@
             <artifactId>ratis-common</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <!-- zookeeper ::start:: -->
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>
+        </dependency>
+        <!-- zookeeper ::end:: -->
     </dependencies>
 
     <build>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/CatalogInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/CatalogInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class CatalogInfo
+{
+    private final String catalogName;
+    private final String connectorName;
+    private final Map<String, String> properties;
+
+    @JsonCreator
+    public CatalogInfo(@JsonProperty("catalogName") String catalogName,
+            @JsonProperty("connectorName") String connectorName,
+            @JsonProperty("properties") Map<String, String> properties)
+    {
+        this.catalogName = catalogName;
+        this.connectorName = connectorName;
+        this.properties = properties;
+    }
+
+    @JsonProperty
+    public String getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @JsonProperty
+    public String getConnectorName()
+    {
+        return connectorName;
+    }
+
+    @JsonProperty
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogResource.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.util.DynamicCatalogJsonUtil;
+import org.apache.zookeeper.CreateMode;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+@Path("/v1/catalog")
+public class DynamicCatalogResource
+{
+    private static final Logger log = Logger.get(DynamicCatalogResource.class);
+    private final DynamicCatalogStoreConfig config;
+    private final String zkPath;
+    private final boolean enabled;
+
+    @Inject
+    public DynamicCatalogResource(DynamicCatalogStoreConfig config)
+    {
+        this.config = config;
+        this.zkPath = config.getZkPath();
+        this.enabled = config.getEnabled();
+    }
+
+    private void isEnabled()
+    {
+        if (!enabled) {
+            log.info("Dynamic catalog is disabled");
+            return;
+        }
+        log.info("Dynamic catalog is enabled");
+    }
+
+    @GET
+    @Path("/list")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<CatalogInfo> list()
+            throws Exception
+    {
+        isEnabled();
+        try {
+            List<String> list = config.getCuratorFramework().getChildren().forPath(zkPath);
+            return list.stream().map(s -> {
+                try {
+                    byte[] bytes = config.getCuratorFramework().getData().forPath(zkPath + "/" + s);
+                    return DynamicCatalogJsonUtil.toObject(new String(bytes), CatalogInfo.class);
+                }
+                catch (Exception e) {
+                    log.error("Failed to get catalog info", e);
+                    return null;
+                }
+            }).filter(Objects::nonNull).collect(Collectors.toList());
+        }
+        catch (Exception e) {
+            log.error("Failed to list catalogs", e);
+            return Collections.emptyList();
+        }
+    }
+
+    @GET
+    @Path("/{catalogName}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public CatalogInfo getCatalogInfo(@PathParam("catalogName") String catalogName)
+    {
+        isEnabled();
+        try {
+            byte[] bytes = config.getCuratorFramework().getData().forPath(zkPath + "/" + catalogName);
+            return DynamicCatalogJsonUtil.toObject(new String(bytes), CatalogInfo.class);
+        }
+        catch (Exception e) {
+            log.error("Failed to get catalog info", e);
+            return null;
+        }
+    }
+
+    @POST
+    @Path("/save")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public void save(CatalogInfo catalogInfo)
+    {
+        isEnabled();
+        try {
+            requireNonNull(catalogInfo.getCatalogName(), "catalogName is null");
+            requireNonNull(catalogInfo.getConnectorName(), "connectorName is null");
+            requireNonNull(catalogInfo.getProperties(), "properties are null");
+            config.getCuratorFramework().create().orSetData().creatingParentsIfNeeded()
+                    .withMode(CreateMode.PERSISTENT)
+                    .forPath(zkPath + "/" + catalogInfo.getCatalogName(),
+                            requireNonNull(DynamicCatalogJsonUtil.toJson(catalogInfo)).getBytes(StandardCharsets.UTF_8));
+        }
+        catch (Exception e) {
+            log.error("Failed to save catalog info", e);
+        }
+    }
+
+    @DELETE
+    @Path("/{catalogName}")
+    public void remove(@PathParam("catalogName") String catalogName)
+    {
+        isEnabled();
+        try {
+            config.getCuratorFramework().delete().deletingChildrenIfNeeded().withVersion(-1).forPath(zkPath + "/" + catalogName);
+        }
+        catch (Exception e) {
+            log.error("Failed to remove catalog info", e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStore.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.discovery.client.Announcer;
+import com.facebook.airlift.discovery.client.ServiceAnnouncement;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.connector.ConnectorManager;
+import com.facebook.presto.spi.ConnectorId;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.TreeCache;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
+import static com.google.common.base.Strings.nullToEmpty;
+
+public class DynamicCatalogStore
+{
+    private static final Logger log = Logger.get(DynamicCatalogStore.class);
+    private final Announcer announcer;
+    private final AtomicBoolean catalogsLoaded = new AtomicBoolean();
+    private final AtomicBoolean catalogsLoading = new AtomicBoolean();
+    private final ConnectorManager connectorManager;
+    private final DynamicCatalogStoreConfig config;
+    private final InternalNodeManager nodeManager;
+
+    @Inject
+    public DynamicCatalogStore(ConnectorManager connectorManager,
+            DynamicCatalogStoreConfig config,
+            Announcer announcer,
+            InternalNodeManager nodeManager)
+    {
+        this.connectorManager = connectorManager;
+        this.config = config;
+        this.announcer = announcer;
+        this.nodeManager = nodeManager;
+    }
+
+    @SuppressWarnings("DuplicatedCode")
+    private static void updateConnectorIdAnnouncement(Announcer announcer, ConnectorId connectorId, InternalNodeManager nodeManager)
+    {
+        //
+        // This code was copied from PrestoServer, and is a hack that should be removed when the connectorId property is removed
+        //
+
+        // get existing announcement
+        ServiceAnnouncement announcement = getPrestoAnnouncement(announcer.getServiceAnnouncements());
+
+        // update connectorIds property
+        Map<String, String> properties = new LinkedHashMap<>(announcement.getProperties());
+        String property = nullToEmpty(properties.get("connectorIds"));
+        Set<String> connectorIds = new LinkedHashSet<>(Splitter.on(',').trimResults().omitEmptyStrings().splitToList(property));
+        connectorIds.add(connectorId.toString());
+        properties.put("connectorIds", Joiner.on(',').join(connectorIds));
+
+        // update announcement
+        announcer.removeServiceAnnouncement(announcement.getId());
+        announcer.addServiceAnnouncement(serviceAnnouncement(announcement.getType()).addProperties(properties).build());
+        announcer.forceAnnounce();
+
+        nodeManager.refreshNodes();
+    }
+
+    private static ServiceAnnouncement getPrestoAnnouncement(Set<ServiceAnnouncement> announcements)
+    {
+        for (ServiceAnnouncement announcement : announcements) {
+            if (announcement.getType().equals("presto")) {
+                return announcement;
+            }
+        }
+        throw new RuntimeException("Presto announcement not found: " + announcements);
+    }
+
+    public boolean areCatalogsLoaded()
+    {
+        return catalogsLoaded.get();
+    }
+
+    public boolean isDynamicEnabled()
+    {
+        return config.getEnabled();
+    }
+
+    public void loadCatalogs()
+    {
+        if (catalogsLoading.compareAndSet(false, true)) {
+            CuratorFramework curatorFramework = config.getCuratorFramework();
+            TreeCache cache = TreeCache.newBuilder(curatorFramework, config.getZkPath()).setCacheData(false).build();
+            try {
+                cache.getListenable().addListener((client, event) -> {
+                    switch (event.getType()) {
+                        case NODE_ADDED:
+                            createCatalog(event.getData());
+                            break;
+                        case NODE_UPDATED:
+                            updateCatalog(event.getData(), event.getData());
+                            break;
+                        case NODE_REMOVED:
+                            removeCatalog(event.getData());
+                            break;
+                        default:
+                            break;
+                    }
+                });
+                cache.start();
+            }
+            catch (Exception e) {
+                log.error(e, "Error while loading catalogs");
+            }
+            catalogsLoaded.set(true);
+        }
+    }
+
+    private void createCatalog(ChildData data)
+    {
+        if (data.getPath().equals(config.getZkPath())) {
+            return;
+        }
+        try {
+            CatalogInfo catalogInfo = new ObjectMapper().readValue(data.getData(), CatalogInfo.class);
+            ConnectorId connectorId = connectorManager.createConnection(catalogInfo.getCatalogName(), catalogInfo.getConnectorName(), catalogInfo.getProperties());
+            updateConnectorIdAnnouncement(announcer, connectorId, nodeManager);
+        }
+        catch (IOException e) {
+            log.error(e, "Error while creating catalog");
+        }
+    }
+
+    private void removeCatalog(ChildData data)
+    {
+        if (data.getPath().equals(config.getZkPath())) {
+            return;
+        }
+        String catalogName = data.getPath().substring(data.getPath().lastIndexOf('/') + 1);
+        connectorManager.dropConnection(catalogName);
+    }
+
+    private void updateCatalog(ChildData oldData, ChildData data)
+    {
+        removeCatalog(oldData);
+        createCatalog(data);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStoreConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DynamicCatalogStoreConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.log.Logger;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicCatalogStoreConfig
+{
+    private static final Logger log = Logger.get(DynamicCatalogStoreConfig.class);
+    private static final Integer TIMEOUT = 30000;
+    private static final Integer SLEEP_TIME = 3000;
+    private static final Integer RETRY_TIMES = 3;
+    private String enabled;
+    private String zkAddress;
+    private String zkPath;
+    private String namespace;
+    private CuratorFramework curatorFramework;
+
+    public boolean getEnabled()
+    {
+        return enabled.equals("true");
+    }
+
+    @Config("catalog.dynamic.enabled")
+    public DynamicCatalogStoreConfig setEnabled(String enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public String getZkAddress()
+    {
+        return (zkAddress == null || zkAddress.isEmpty()) ? "127.0.0.1:2181" : zkAddress;
+    }
+
+    @Config("catalog.dynamic.zk.address")
+    public DynamicCatalogStoreConfig setZkAddress(String zkAddress)
+    {
+        this.zkAddress = zkAddress;
+        return this;
+    }
+
+    public String getZkPath()
+    {
+        return zkPath;
+    }
+
+    @Config("catalog.dynamic.zk.path")
+    public DynamicCatalogStoreConfig setZkPath(String zkPath)
+    {
+        this.zkPath = zkPath;
+        return this;
+    }
+
+    public String getNamespace()
+    {
+        return namespace;
+    }
+
+    @Config("catalog.dynamic.zk.namespace")
+    public DynamicCatalogStoreConfig setNamespace(String namespace)
+    {
+        this.namespace = namespace;
+        return this;
+    }
+
+    public CuratorFramework getCuratorFramework()
+    {
+        createCuratorFramework();
+        return curatorFramework;
+    }
+
+    private synchronized void createCuratorFramework()
+    {
+        if (curatorFramework == null) {
+            requireNonNull(zkAddress, "zookeeper address is null");
+            requireNonNull(zkPath, "zookeeper path is null");
+            log.info("get catalog from zookeeper, address: %s, path: %s", zkAddress, zkPath);
+            RetryPolicy retryPolicy = new ExponentialBackoffRetry(SLEEP_TIME, RETRY_TIMES);
+            curatorFramework = org.apache.curator.framework.CuratorFrameworkFactory.builder().connectString(zkAddress).sessionTimeoutMs(TIMEOUT).connectionTimeoutMs(TIMEOUT).retryPolicy(retryPolicy).namespace(namespace).build();
+            curatorFramework.start();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -39,6 +39,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorModule;
 import com.facebook.presto.metadata.Catalog;
 import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.DynamicCatalogStore;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.security.AccessControlManager;
@@ -146,8 +147,16 @@ public class PrestoServer
 
             ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
 
-            if (!serverConfig.isResourceManager()) {
-                injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            // hack: load catalogs dynamically if enabled
+            DynamicCatalogStore dynamicCatalogStore = injector.getInstance(DynamicCatalogStore.class);
+
+            if (dynamicCatalogStore.isDynamicEnabled()) {
+                dynamicCatalogStore.loadCatalogs();
+            }
+            else {
+                if (!serverConfig.isResourceManager()) {
+                    injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+                }
             }
 
             // TODO: remove this huge hack

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -91,6 +91,9 @@ import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.ColumnPropertyManager;
 import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
 import com.facebook.presto.metadata.DiscoveryNodeManager;
+import com.facebook.presto.metadata.DynamicCatalogResource;
+import com.facebook.presto.metadata.DynamicCatalogStore;
+import com.facebook.presto.metadata.DynamicCatalogStoreConfig;
 import com.facebook.presto.metadata.ForNodeManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.HandleJsonModule;
@@ -593,6 +596,14 @@ public class ServerMainModule
         binder.bind(FunctionAndTypeManager.class).in(Scopes.SINGLETON);
         binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
 
+        // hack: load catalogs dynamically if enabled
+        binder.bind(DynamicCatalogStore.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(DynamicCatalogStoreConfig.class);
+        binder.bind(StaticFunctionNamespaceStore.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(StaticFunctionNamespaceStoreConfig.class);
+        binder.bind(FunctionAndTypeManager.class).in(Scopes.SINGLETON);
+        binder.bind(MetadataManager.class).in(Scopes.SINGLETON);
+
         if (serverConfig.isCatalogServerEnabled() && serverConfig.isCoordinator()) {
             binder.bind(RemoteMetadataManager.class).in(Scopes.SINGLETON);
             binder.bind(Metadata.class).to(RemoteMetadataManager.class).in(Scopes.SINGLETON);
@@ -600,6 +611,9 @@ public class ServerMainModule
         else {
             binder.bind(Metadata.class).to(MetadataManager.class).in(Scopes.SINGLETON);
         }
+
+        // hack: bind restful ports to add/remove catalogs
+        jaxrsBinder(binder).bind(DynamicCatalogResource.class);
 
         // row expression utils
         binder.bind(DomainTranslator.class).to(RowExpressionDomainTranslator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/util/DynamicCatalogJsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/DynamicCatalogJsonUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.util;
+
+import com.facebook.airlift.log.Logger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+public class DynamicCatalogJsonUtil
+{
+    private static final Logger log = Logger.get(DynamicCatalogJsonUtil.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private DynamicCatalogJsonUtil() {}
+
+    public static <T> T toObject(String json, Class<T> clazz)
+    {
+        try {
+            return mapper.readValue(json, clazz);
+        }
+        catch (Exception e) {
+            log.error("Failed to convert json to object", e);
+            return null;
+        }
+    }
+
+    public static <T> List<T> toObjectArray(String json, Class<T> clazz)
+    {
+        try {
+            return mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, clazz));
+        }
+        catch (Exception e) {
+            log.error("Failed to convert json to object array", e);
+            return null;
+        }
+    }
+
+    public static <T> String toJson(T object)
+    {
+        try {
+            return mapper.writeValueAsString(object);
+        }
+        catch (Exception e) {
+            log.error("Failed to convert object to json", e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Description
<!---Describe your changes in detail-->
Introduce https://github.com/thestyleofme/prestosql to the newer Presto.
Personal use only, due to flaws and limitations when when ZooKeeper was introduced.

## Motivation and Context
<!---Why is this change required? What problem does it solve?-->
<!---If it fixes an open issue, please link to the issue here.-->
To enable dynamic catalog management and sync catalog changes between multiple nodes.

## Impact
<!---Describe any public API or user-facing feature change or any performance impact-->
The following options are available in config.properties.
```
catalog.dynamic.enabled=true
catalog.dynamic.zk.address=localhost:2181
catalog.dynamic.zk.namespace=presto
catalog.dynamic.zk.path=/catalog/metadata
```
